### PR TITLE
Node < 0.10 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - '0.10'
+  - '0.8'

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
-var tmpdir = require('os').tmpdir();
+var os = require('os');
+var tmpdir = (os.tmpdir || os.tmpDir)();
 var uuid = require('uuid');
 
 module.exports = function (ext) {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
-var tmpdir = require('os').tmpdir();
+var os = require('os');
+var tmpdir = (os.tmpdir || os.tmpDir)();
 var tempfile = require('./index');
 
 it('should generate a random temp file path', function () {


### PR DESCRIPTION
Using Node < 0.10 (test with Node v0.8.2):

```
var tmpdir = require('os').tmpdir();
TypeError: Object #<Object> has no method 'tmpdir'
```

Node.js v0.10: [`os.tmpdir()`](http://nodejs.org/api/os.html#os_os_tmpdir)
Node.js < v0.8: [`os.tmpDir()`](http://nodejs.org/docs/v0.8.0/api/os.html#os_os_tmpdir)
