### PR TITLE
support for different 'os' versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
-var tmpdir = require('os').tmpdir();
+var os = require('os');
+var tmpdir = (os.tmpdir || os.tmpDir)();
 var uuid = require('uuid');
 
 module.exports = function (ext) {


### PR DESCRIPTION
So basically tmpdir was renamed into tmpDir. So we should use whichever version is available.
