### PR TITLE
Have a fallback ready if require('os').tmpdir isn't available.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var path = require('path');
-var tmpdir = require('os').tmpdir();
 var uuid = require('uuid');
+var tmpdir = require('./tmpdir');
 
 module.exports = function (ext) {
 	return path.join(tmpdir, uuid.v4() + (ext || ''));

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 'use strict';
 var assert = require('assert');
-var tmpdir = require('os').tmpdir();
+var tmpdir = require('./tmpdir');
 var tempfile = require('./index');
 
 it('should generate a random temp file path', function () {

--- a/tmpdir.js
+++ b/tmpdir.js
@@ -1,0 +1,28 @@
+var fs = require('fs'),
+    tmpdir,
+    os;
+try {
+    os = require('os');
+} catch (e) {}
+
+if (os && os.tmpdir) {
+    tmpdir = os.tmpdir();
+} else {
+    var environmentVariableNames = ['TMPDIR', 'TMP', 'TEMP'];
+    for (var i = 0 ; i < environmentVariableNames.length ; i += 1) {
+        var environmentVariableValue = process.env[environmentVariableNames[i]];
+        if (environmentVariableValue) {
+            tmpdir = fs.realpathSync(environmentVariableValue);
+            break;
+        }
+    }
+    if (!tmpdir) {
+        if (process.platform === 'win32') {
+            tmpdir = fs.realpathSync('c:\\tmp');
+        } else {
+            tmpdir = fs.realpathSync('/tmp');
+        }
+    }
+}
+
+module.exports = tmpdir;


### PR DESCRIPTION
This adds node.js 0.8 compatibility.

After updating node-pngquant to node-pngquant-bin 0.1.7 compatibility with node.js 0.8.x was lost because it doesn't have `os.tmpdir()`. I'd really like to stay compatible with 0.8.x for at least a little longer, so please consider merging this.

I copied the implementation from my own module that does pretty much the same: https://github.com/papandreou/node-gettemporaryfilepath :)
