### PR TITLE
Fall back to os.tmpDir if os.tmpdir is not found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
-var tmpdir = require('os').tmpdir();
+var os = require('os');
+var tmpdir = (os.tmpdir || os.tmpDir)();
 var uuid = require('uuid');
 
 module.exports = function (ext) {


### PR DESCRIPTION
This makes the module work in node.js 0.8.

Superseedes https://github.com/sindresorhus/tempfile/pull/6 (although this one doesn't support 0.6 and below).
